### PR TITLE
Minor changes in scanning logic, new x64 patterns

### DIFF
--- a/src/stackstack/scan.py
+++ b/src/stackstack/scan.py
@@ -26,8 +26,11 @@ class YaraScanner(ScanEngineBase):
         x64_rules = [
             """rule scan_a{strings: $ = {c6 45 ?? 00 c6 45 ?? ?? c6 45} condition: all of them}""",
             """rule scan_b{strings: $ = {c6 85 [2-3] ff ff 00 [0-2] c6 85 [2-3] ff ff} condition: all of them}""",
-            """rule scan_c{strings: $ = {(c6|c7) 4? [2-5] (c6|c7) 4? } condition: all of them}""",
-            """rule scan_d{strings: $ = {(c6|c7) 4? ?? 00 (c6|c7) 4? ?? ?? (c6|c7) 4? } condition: all of them}"""
+            """rule scan_c{strings: $ = {(c6|c7) 4? [2-6] (c6|c7) 4? } condition: all of them}""",
+            """rule scan_d{strings: $ = {(c6|c7) 4? ?? 00 (c6|c7) 4? ?? ?? (c6|c7) 4? } condition: all of them}""",
+            """rule scan_e{strings: $ = {(c6|c7) 85 [4] ?? 00 00 00 [0-5] (c6|c7) 85 ?? 0? 00 00 ??} condition: all of them}""",
+            """rule scan_f{strings: $ = {(c6|c7) 4? [2-3] 00 00 00 [0-5] 8B 4? ??} condition: all of them}""",
+            """rule scan_g{strings: $ = {(c6|c7) 85 ?? 0? 00 00 ?? (c6|c7) 85 ?? 0? 00 00 ??} condition: all of them}""",
         ]
 
         x86_rules = [


### PR DESCRIPTION
Hey @idiom !

68f5ccc7a37b00e72d32941a51c513e580f2a9e7 Changes the scanning logic so that matches are iterated in the same order always. It also adds a change in `scan_function` to avoid skipping matches at the beginning of functions.

a48f84d2c6fbec12d0cf60b5f2eefb25bcb8343b Adds new patterns to the default x64 YARA rules. See some disassembly snippet examples that the new patterns will match on:

### scan_e

```
.text:000000014008E38C C7 85 C0 00 00 00 4D 00 00 00                                   mov     [rbp+270h+var_1B0], 4Dh ; 'M' ; Decoded: %s CreateFileA error
.text:000000014008E396 33 C0                                                           xor     eax, eax
.text:000000014008E398 C6 85 C4 00 00 00 68                                            mov     [rbp+270h+var_1AC], 68h ; 'h'
.text:000000014008E39F 48 8B D3                                                        mov     rdx, rbx
.text:000000014008E3A2 C6 85 C5 00 00 00 3E                                            mov     [rbp+270h+var_1AB], 3Eh ; '>'
.text:000000014008E3A9 C6 85 C6 00 00 00 6D                                            mov     [rbp+270h+var_1AA], 6Dh ; 'm'
.text:000000014008E3B0 C6 85 C7 00 00 00 0E                                            mov     [rbp+270h+var_1A9], 0Eh
```

### scan_f

```
.text:000000014008D89E C7 45 A8 7D 00 00 00                                            mov     [rbp+270h+var_2C8], 7Dh ; '}' ; Decoded: MapViewOfFie
.text:000000014008D8A5 41 B5 65                                                        mov     r13b, 65h ; 'e'
.text:000000014008D8A8 8B 45 A8                                                        mov     eax, [rbp+270h+var_2C8]
.text:000000014008D8AB 48 8B D3                                                        mov     rdx, rbx
.text:000000014008D8AE 34 4D                                                           xor     al, 4Dh
.text:000000014008D8B0 88 45 AC                                                        mov     [rbp+270h+var_2C4], al
.text:000000014008D8B3 8B 45 A8                                                        mov     eax, [rbp+270h+var_2C8]
.text:000000014008D8B6 FE C0                                                           inc     al
.text:000000014008D8B8 34 61                                                           xor     al, 61h
.text:000000014008D8BA 88 45 AD                                                        mov     [rbp+270h+var_2C3], al
```

### scan_g

```
.text:0000000140084CA8 C6 85 88 00 00 00 5F                                            mov     [rbp+4F0h+var_468], 5Fh ; '_' ; Decoded: SELECT SerialNumber FROM CIM_PhysicalFrame
.text:0000000140084CAF C6 85 89 00 00 00 51                                            mov     [rbp+4F0h+var_467], 51h ; 'Q'
.text:0000000140084CB6 C6 85 8A 00 00 00 58                                            mov     [rbp+4F0h+var_466], 58h ; 'X'
.text:0000000140084CBD C6 85 8B 00 00 00 51                                            mov     [rbp+4F0h+var_465], 51h ; 'Q'
.text:0000000140084CC4 C6 85 8C 00 00 00 4F                                            mov     [rbp+4F0h+var_464], 4Fh ; 'O'
.text:0000000140084CCB C6 85 8D 00 00 00 60                                            mov     [rbp+4F0h+var_463], 60h ; '`'
.text:0000000140084CD2 C6 85 8E 00 00 00 2C                                            mov     [rbp+4F0h+var_462], 2Ch ; ','
```
